### PR TITLE
Absolute URL to Figlet.NET

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -2,7 +2,7 @@
 
 [FIGlet](http://www.figlet.org/) is a program for making large letters out of ordinary text.
 
-This PowerShell module is a set of commands for PowerShell, based on @auriou's [FIGlet.Net library](/auriou/FIGlet), and my [Pansies](/PoshCode/Pansies) module for doing colors in PowerShell using ANSI escape sequences.
+This PowerShell module is a set of commands for PowerShell, based on @auriou's [FIGlet.Net library](https://github.com/auriou/FIGlet), and my [Pansies](/PoshCode/Pansies) module for doing colors in PowerShell using ANSI escape sequences.
 
 It's this easy:
 ![screenshot](https://raw.githubusercontent.com/Jaykul/Figlet/resources/screenshot.png)


### PR DESCRIPTION
Original URL resolved to `https://github.com/Jaykul/Figlet/blob/master/auriou/FIGlet` on the GitHub.